### PR TITLE
APPS-4542 Bump minimum versions for `spryker-sdk/async-api`, `spryker-sdk/sync-api` to prevent ambiguous loading of generated transfer objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "spryker-sdk/spryk": "^0.4.0",
         "symfony/console": "^5.3",
         "symfony/finder": "^5.3",
-        "spryker-sdk/async-api": "^0.2.1",
-        "spryker-sdk/sync-api": "^0.1.0",
+        "spryker-sdk/async-api": "^0.2.3",
+        "spryker-sdk/sync-api": "^0.1.1",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
- Developer(s): @k4emic

- Ticket: https://spryker.atlassian.net/browse/APPS-4542

- Release Group: URL_HERE

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Acp                   | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Acp

##### Change log

### Improvements

- Bump minimum versions for `spryker-sdk/async-api` and `spryker-sdk/sync-api` to no longer allow versions of these packages which could result in ambiguous autoloading of transfer objects.


