### PR TITLE
APPS-4723 Fixed wrong class extension.

### DIFF
--- a/src/Transfer/AppTranslationRequestTransfer.php
+++ b/src/Transfer/AppTranslationRequestTransfer.php
@@ -6,8 +6,6 @@
 
 namespace Transfer;
 
-use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
-
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE

--- a/src/Transfer/ManifestCollectionTransfer.php
+++ b/src/Transfer/ManifestCollectionTransfer.php
@@ -7,7 +7,6 @@
 namespace Transfer;
 
 use ArrayObject;
-use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
 
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR

--- a/src/Transfer/ManifestConditionsTransfer.php
+++ b/src/Transfer/ManifestConditionsTransfer.php
@@ -6,8 +6,6 @@
 
 namespace Transfer;
 
-use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
-
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE

--- a/src/Transfer/ManifestConfigurationTransfer.php
+++ b/src/Transfer/ManifestConfigurationTransfer.php
@@ -6,8 +6,6 @@
 
 namespace Transfer;
 
-use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
-
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE

--- a/src/Transfer/ManifestCriteriaTransfer.php
+++ b/src/Transfer/ManifestCriteriaTransfer.php
@@ -6,8 +6,6 @@
 
 namespace Transfer;
 
-use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
-
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE

--- a/src/Transfer/ManifestTranslationTransfer.php
+++ b/src/Transfer/ManifestTranslationTransfer.php
@@ -6,8 +6,6 @@
 
 namespace Transfer;
 
-use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
-
 /**
  * !!! THIS FILE IS AUTO-GENERATED, EVERY CHANGE WILL BE LOST WITH THE NEXT RUN OF TRANSFER GENERATOR
  * !!! DO NOT CHANGE ANYTHING IN THIS FILE


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/APPS-4723

- Docs PR: ACADEMY_URL_HERE

- Release Group: URL_HERE

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Acp                   | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Acp

##### Change log

### Fixes

- Fixed wrong class extension in Transfer objects.

